### PR TITLE
Update for Atlantis 0.15 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Update systemd service resource to support environment file/vars
+
+### Changed
+
+- Fix to properly use recommended YAML.dump() method in template
+- Update systemd service resource to remove ExecStop for compatibility with v0.15
+- Update documentation to reflect changed/deprecated values in Atlantis config
+
 ## [1.0.0] - 2020-10-13
 
 ### Added
@@ -18,8 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update README.md CHANGELOG.md
 - Cookstyle fixes
 - Update ark dependency to 5.0
-
-### Removed
 
 - **BREAKING CHANGE:** Updated config template to convert hash to YAML instead of custom logic
   - log-level must be lower case

--- a/documentation/resource_atlantis_config.md
+++ b/documentation/resource_atlantis_config.md
@@ -33,8 +33,7 @@ config_vars = {
   'gh-webhook-secret'     => 'A_GITHUB_WEBHOOK_SECRET',
   'log-level'             => 'info',
   'port'                  => 4141,
-  'require-approval'      => true,
-  'repo-whitelist'        => %w(org/repo1 org/repo2).join(','),
+  'repo-allowlist'        => %w(org/repo1 org/repo2).join(','),
 }
 
 atlantis_config 'atlantis' do

--- a/documentation/resource_atlantis_service_systemd.md
+++ b/documentation/resource_atlantis_service_systemd.md
@@ -14,15 +14,21 @@
 | name                          | Type            | Default                   | Description   |
 | ----------------------------- | --------------- | ------------------------- | ------------- |
 | atlantis_bin_location         | String          | `/usr/local/bin/atlantis` |               |
-| atlantis_config_name          | String          | `atlantis.yml`            |               |
+| atlantis_config_name           | String          | `atlantis.yml`            |               |
 | atlantis_group                | String          | `atlantis`                |               |
 | atlantis_home                 | String          | `/opt/atlantis`           |               |
 | timeout_stop_sec              | String, Integer | 5                         |               |
 | atlantis_success_exit_status  | String, Integer | 143                       | The exit status code 143 = 128 + 15 = default terminate by system when the application doesn't have one |
 | atlantis_user                 | String          | `atlantis`                |               |
+| use_exec_stop                 | true, false     | true                      | Atlantis 0.15 introduced a delayed shutdown option and it doesnt play nice with kill. Setting this to false removes the ExecStop which allows Atlantis to gracefully shutdown. |
+| environment                   | String          |                           | Environment variable(s) for Atlantis service |
+| environment_file               | String          |                           | Environment file containing variable for Atlantis use |
 
 ## Examples
 
 ```ruby
-atlantis_service_systemd 'atlantis'
+atlantis_service_systemd 'atlantis' do
+  use_exec_stop false
+  environment 'PATH=$PATH:/usr/local/bin/terraform'
+end
 ```

--- a/documentation/resource_atlantis_service_systemd.md
+++ b/documentation/resource_atlantis_service_systemd.md
@@ -14,21 +14,21 @@
 | name                          | Type            | Default                   | Description   |
 | ----------------------------- | --------------- | ------------------------- | ------------- |
 | atlantis_bin_location         | String          | `/usr/local/bin/atlantis` |               |
-| atlantis_config_name           | String          | `atlantis.yml`            |               |
+| atlantis_config_name          | String          | `atlantis.yml`            |               |
 | atlantis_group                | String          | `atlantis`                |               |
 | atlantis_home                 | String          | `/opt/atlantis`           |               |
 | timeout_stop_sec              | String, Integer | 5                         |               |
 | atlantis_success_exit_status  | String, Integer | 143                       | The exit status code 143 = 128 + 15 = default terminate by system when the application doesn't have one |
 | atlantis_user                 | String          | `atlantis`                |               |
 | use_exec_stop                 | true, false     | true                      | Atlantis 0.15 introduced a delayed shutdown option and it doesnt play nice with kill. Setting this to false removes the ExecStop which allows Atlantis to gracefully shutdown. |
-| environment                   | String          |                           | Environment variable(s) for Atlantis service |
-| environment_file               | String          |                           | Environment file containing variable for Atlantis use |
+| environment                   | String, Array   |                           | Environment variable(s) for Atlantis service |
+| environment_file              | String, Array   |                           | Environment file containing variable for Atlantis use |
 
 ## Examples
 
 ```ruby
 atlantis_service_systemd 'atlantis' do
   use_exec_stop false
-  environment 'PATH=$PATH:/usr/local/bin/terraform'
+  environment ['John=Basement', 'Tom=Roof']
 end
 ```

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -28,7 +28,6 @@ action :setup do
     'Service' => {
       'Type' => 'simple',
       'ExecStart' => "#{new_resource.atlantis_bin_location} server --config #{new_resource.atlantis_home}/#{new_resource.atlantis_config_name}",
-      'TimeoutStopSec' => new_resource.timeout_stop_sec.to_i,
       'SuccessExitStatus' => new_resource.atlantis_success_exit_status.to_i, # support strings
       'User' => new_resource.atlantis_user,
       'Group' => new_resource.atlantis_group,
@@ -39,6 +38,7 @@ action :setup do
     },
   }
   service_content['Service']['ExecStop'] = '/bin/kill $MAINPID' if new_resource.use_exec_stop
+  service_content['Service']['TimeoutStopSec'] = new_resource.timeout_stop_sec.to_i if new_resource.use_exec_stop
   service_content['Service']['Environment'] = new_resource.environment if new_resource.environment
   service_content['Service']['EnvironmentFile'] = new_resource.environment_file if new_resource.environment_file
 

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -14,8 +14,8 @@ property :atlantis_success_exit_status, [Integer, String], default: 143
 property :atlantis_user, String, default: 'atlantis'
 property :atlantis_user, String, default: 'atlantis'
 property :use_exec_stop, [true, false], default: true
-property :environment, String
-property :environment_file, String
+property :environment, [String, Array]
+property :environment_file, [String, Array]
 
 default_action :setup
 

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -8,36 +8,42 @@ property :atlantis_bin_location, String, default: '/usr/local/bin/atlantis'
 property :atlantis_config_name, String, default: 'atlantis.yaml'
 property :atlantis_group, String, default: 'atlantis'
 property :atlantis_home, String, default: '/opt/atlantis'
-property :timeout_stop_sec, [Integer, String ], default: 5
+property :timeout_stop_sec, [Integer, String], default: 5
 # The exit status code 143 = 128 + 15 = default terminate by system when the application doesn't have one
 property :atlantis_success_exit_status, [Integer, String], default: 143
 property :atlantis_user, String, default: 'atlantis'
+property :atlantis_user, String, default: 'atlantis'
+property :use_exec_stop, [true, false], default: true
+property :environment, String
+property :environment_file, String
 
 default_action :setup
 
 action :setup do
+  service_content = {
+    'Unit' => {
+      'Description' => 'Atlantis',
+      'After' => 'network-online.target',
+    },
+    'Service' => {
+      'Type' => 'simple',
+      'ExecStart' => "#{new_resource.atlantis_bin_location} server --config #{new_resource.atlantis_home}/#{new_resource.atlantis_config_name}",
+      'TimeoutStopSec' => new_resource.timeout_stop_sec.to_i,
+      'SuccessExitStatus' => new_resource.atlantis_success_exit_status.to_i, # support strings
+      'User' => new_resource.atlantis_user,
+      'Group' => new_resource.atlantis_group,
+      'Restart' => 'always',
+    },
+    'Install' => {
+      'WantedBy' => 'multi-user.target',
+    },
+  }
+  service_content['Service']['ExecStop'] = '/bin/kill $MAINPID' if new_resource.use_exec_stop
+  service_content['Service']['Environment'] = new_resource.environment if new_resource.environment
+  service_content['Service']['EnvironmentFile'] = new_resource.environment_file if new_resource.environment_file
+
   systemd_unit 'atlantis.service' do
-    content(
-      'Unit' => {
-        'Description' => 'Atlantis',
-        'After' => 'network.target',
-      },
-      'Service' => {
-        'Type' => 'simple',
-        'ExecStart' => "#{new_resource.atlantis_bin_location} server --config #{new_resource.atlantis_home}/#{new_resource.atlantis_config_name}",
-        'ExecStop' => '/bin/kill $MAINPID',
-        'TimeoutStopSec' => new_resource.timeout_stop_sec.to_i,
-        'SuccessExitStatus' => new_resource.atlantis_success_exit_status.to_i, # support strings
-        'User' => new_resource.atlantis_user,
-        'Group' => new_resource.atlantis_group,
-        # not sure if anyone needs this for now lets leave it out
-        # 'Environment' => 'PATH=$PATH:/usr/local/bin/terraform',
-        'Restart' => 'always',
-      },
-      'Install' => {
-        'WantedBy' => 'multi-user.target',
-      }
-    )
+    content(service_content)
     action [:create, :enable, :start]
   end
 end

--- a/templates/default/atlantis.yaml.erb
+++ b/templates/default/atlantis.yaml.erb
@@ -1,5 +1,4 @@
 # yamllint disable-file
 # ################# MANAGED BY AUTOMATION DO NOT EDIT ####################
 # ###################### Atlantis Configuration ##########################
-<% require 'yaml' %>
-<%= @vars.to_yaml %>
+<%= YAML.dump(@vars) %>

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -16,8 +16,7 @@ config_vars = {
   'gh-webhook-secret'     => 'A_GITHUB_WEBHOOK_SECRET',
   'log-level'             => 'info',
   'port'                  => 4141,
-  'require-approval'      => true,
-  'repo-whitelist'        => %w(org/repo1 org/repo2).join(','),
+  'repo-allowlist'        => %w(org/repo1 org/repo2).join(','),
 }
 
 atlantis_config 'atlantis' do
@@ -28,17 +27,20 @@ end
 package %w(unzip git)
 
 atlantis_installer 'atlantis' do
-  version '0.4.5'
-  checksum 'ca3d237a75f76e08cf4d8a33eba8aaceefeee8a21c4bc81ed971e88350e372b5'
+  version '0.15.0'
+  checksum 'a236e7c9df159f8787b143c670f1899dd4bc4349f23ed696468600280fa1266e'
 end
 
 terraform_installer 'terraform' do
-  version '0.11.7'
-  checksum '6b8ce67647a59b2a3f70199c304abca0ddec0e49fd060944c26f666298e23418'
+  version '0.13.3'
+  checksum '35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b'
 end
 
 if node['platform_version'] == '14.04'
   atlantis_service_upstart 'atlantis'
 else
-  atlantis_service_systemd 'atlantis'
+  atlantis_service_systemd 'atlantis' do
+    use_exec_stop false
+    environment 'John=Basement'
+  end
 end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -41,6 +41,6 @@ if node['platform_version'] == '14.04'
 else
   atlantis_service_systemd 'atlantis' do
     use_exec_stop false
-    environment 'John=Basement'
+    environment ['John=Basement', 'Tom=Roof']
   end
 end

--- a/test/integration/default/atlantis.rb
+++ b/test/integration/default/atlantis.rb
@@ -11,7 +11,7 @@ describe file(atlantis_bin) do
   # if needed you may have to install `coreutils` (package name for deb derivitives)
   # root@dokken:/# sha256sum /usr/local/bin/atlantis/atlantis
   # c094def53949d658bb3ead360b86a432e3cc48609252621da7855f7fc7f0d136  /usr/local/bin/atlantis/atlantis
-  its('sha256sum') { should eq 'c094def53949d658bb3ead360b86a432e3cc48609252621da7855f7fc7f0d136' }
+  its('sha256sum') { should eq 'e4169fdad7cd01809565b723b0c3a30f8119481e1cee79be20cf577f6607865e' }
 end
 
 describe command("#{atlantis_bin} version") do
@@ -33,8 +33,7 @@ describe yaml('/opt/atlantis/atlantis.yaml'), :sensitive do
   its('gh-webhook-secret') { should eq 'A_GITHUB_WEBHOOK_SECRET' }
   its('log-level') { should eq 'info' }
   its('port') { should eq 4141 }
-  its('require-approval') { should eq true }
-  its('repo-whitelist') { should eq 'org/repo1,org/repo2' }
+  its('repo-allowlist') { should eq 'org/repo1,org/repo2' }
 end
 
 describe http('localhost:4141/healthz') do

--- a/test/integration/default/service.rb
+++ b/test/integration/default/service.rb
@@ -18,7 +18,7 @@ control 'Atlantis Service SystemD' do
     its('Service.Type') { should cmp 'simple' }
     its('Service.User') { should cmp 'atlantis' }
     its('Service.Group') { should cmp 'atlantis' }
-    its('Service.Environment') { should cmp 'John=Basement' }
+    its('Service.Environment') { should cmp 'Tom=Roof' }
     its('Service.ExecStart') { should cmp '/usr/local/bin/atlantis server --config /opt/atlantis/atlantis.yaml' }
     its('Service.TimeoutStopSec') { should cmp 5 }
     its('Service.SuccessExitStatus') { should cmp 143 }

--- a/test/integration/default/service.rb
+++ b/test/integration/default/service.rb
@@ -1,7 +1,29 @@
 # frozen_string_literal: true
 
-describe service('atlantis') do
-  it { should be_installed }
-  it { should be_enabled }
-  it { should be_running }
+control 'Atlantis Service Common' do
+  describe service('atlantis') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+end
+
+control 'Atlantis Service SystemD' do
+  only_if { os.release != '14.04' }
+
+  describe ini('/etc/systemd/system/atlantis.service') do
+    its('Unit.Description') { should cmp 'Atlantis' }
+    its('Unit.After') { should cmp 'network-online.target' }
+
+    its('Service.Type') { should cmp 'simple' }
+    its('Service.User') { should cmp 'atlantis' }
+    its('Service.Group') { should cmp 'atlantis' }
+    its('Service.Environment') { should cmp 'John=Basement' }
+    its('Service.ExecStart') { should cmp '/usr/local/bin/atlantis server --config /opt/atlantis/atlantis.yaml' }
+    its('Service.TimeoutStopSec') { should cmp 5 }
+    its('Service.SuccessExitStatus') { should cmp 143 }
+    its('Service.Restart') { should cmp 'always' }
+
+    its('Install.WantedBy') { should cmp 'multi-user.target' }
+  end
 end

--- a/test/integration/default/service.rb
+++ b/test/integration/default/service.rb
@@ -20,7 +20,6 @@ control 'Atlantis Service SystemD' do
     its('Service.Group') { should cmp 'atlantis' }
     its('Service.Environment') { should cmp 'Tom=Roof' }
     its('Service.ExecStart') { should cmp '/usr/local/bin/atlantis server --config /opt/atlantis/atlantis.yaml' }
-    its('Service.TimeoutStopSec') { should cmp 5 }
     its('Service.SuccessExitStatus') { should cmp 143 }
     its('Service.Restart') { should cmp 'always' }
 

--- a/test/integration/default/terraform.rb
+++ b/test/integration/default/terraform.rb
@@ -11,7 +11,7 @@ describe file(terraform_bin) do
   # if needed you may have to install `coreutils` (package name for deb derivitives)
   # root@dokken:/# sha256sum /usr/local/bin/terraform/terraform
   # 00cc2e727e662fb81c789b2b8371d82d6be203ddc76c49232ed9c17b4980949a  /usr/local/bin/terraform/terraform
-  its('sha256sum') { should eq '00cc2e727e662fb81c789b2b8371d82d6be203ddc76c49232ed9c17b4980949a' }
+  its('sha256sum') { should eq 'dba9536bd31ffceb3abdc49f2eeed0fad506bab30d32d0a605d0a8d9f92f8e6f' }
 end
 
 describe command("#{terraform_bin} --version") do


### PR DESCRIPTION
# Description

### Added

- Update systemd service resource to support environment file/vars

### Changed

- Fix to properly use recommended YAML.dump() method in template
- Update systemd service resource to remove ExecStop for compatibility with v0.15
- Update documentation to reflect changed/deprecated values in Atlantis config

Although the tests only grab the last value i validated in the service unit manually that they both appear correctly:
![image](https://user-images.githubusercontent.com/24723497/96890894-1ced7880-1456-11eb-8b8e-71a7aa122d59.png)

## Check List

- [x] All tests pass. See https://github.com/sous-chefs/atlantis/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
