### PR TITLE
Add support for Terragrunt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Support for installing terragrunt and documentation of examples for configuration
+
+### Fixed
+
+- Ark only support intergers on groups not owners
+- Systemd resource user property was listed twice
+
 ## [1.1.0] - 2020-10-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for installing terragrunt and documentation of examples for configuration
+- Default version support for installers to get setup without having to lookup versions
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ May continue working on older EOL versions of Chef
 - [atlantis_service_systemd](https://github.com/sous-chefs/atlantis/blob/master/documentation/resource_atlantis_service_systemd.md)
 - [atlantis_service_upstart](https://github.com/sous-chefs/atlantis/blob/master/documentation/resource_atlantis_service_upstart.md)
 - [terraform_installer](https://github.com/sous-chefs/atlantis/blob/master/documentation/resource_terraform_installer.md)
+- [terragrunt_installer](https://github.com/sous-chefs/atlantis/blob/master/documentation/resource_terragrunt_installer.md)
 - [atlantis_user_group_setup](https://github.com/sous-chefs/atlantis/blob/master/documentation/resource_atlantis_user_group_setup.md)
 
 ## Usage

--- a/documentation/resource_atlantis_installer.md
+++ b/documentation/resource_atlantis_installer.md
@@ -16,7 +16,7 @@
 | checksum                    | String          |                                                             | Required      |
 | download_base_url           | String          | `https://github.com/runatlantis/atlantis/releases/download` |               |
 | group                       | String, Integer | `atlantis`                                                  |               |
-| owner                       | String, Integer | `atlantis`                                                  |               |
+| owner                       | String          | `atlantis`                                                  |               |
 | mode                        | String, Integer | `0755`                                                      |               |
 | version                     | String          |                                                             | Required      |
 

--- a/documentation/resource_atlantis_installer.md
+++ b/documentation/resource_atlantis_installer.md
@@ -11,20 +11,20 @@
 
 ## Properties
 
-| name                        | Type            | Default                                                     | Description   |
-| --------------------------- | --------------- | ----------------------------------------------------------- | ------------- |
-| checksum                    | String          |                                                             | Required      |
-| download_base_url           | String          | `https://github.com/runatlantis/atlantis/releases/download` |               |
-| group                       | String, Integer | `atlantis`                                                  |               |
-| owner                       | String          | `atlantis`                                                  |               |
-| mode                        | String, Integer | `0755`                                                      |               |
-| version                     | String          |                                                             | Required      |
+| name                        | Type            | Default                                                            | Description   |
+| --------------------------- | --------------- | ------------------------------------------------------------------ | ------------- |
+| checksum                    | String          | `a236e7c9df159f8787b143c670f1899dd4bc4349f23ed696468600280fa1266e` | Required      |
+| download_base_url           | String          | `https://github.com/runatlantis/atlantis/releases/download`        |               |
+| group                       | String, Integer | `atlantis`                                                         |               |
+| owner                       | String          | `atlantis`                                                         |               |
+| mode                        | String, Integer | `0755`                                                             |               |
+| version                     | String          | `0.15.0`                                                           | Required      |
 
 ## Examples
 
 ```ruby
 atlantis_installer 'atlantis' do
-  version '0.4.5'
-  checksum 'ca3d237a75f76e08cf4d8a33eba8aaceefeee8a21c4bc81ed971e88350e372b5'
+  version '0.15.0'
+  checksum 'a236e7c9df159f8787b143c670f1899dd4bc4349f23ed696468600280fa1266e'
 end
 ```

--- a/documentation/resource_atlantis_installer.md
+++ b/documentation/resource_atlantis_installer.md
@@ -23,8 +23,5 @@
 ## Examples
 
 ```ruby
-atlantis_installer 'atlantis' do
-  version '0.15.0'
-  checksum 'a236e7c9df159f8787b143c670f1899dd4bc4349f23ed696468600280fa1266e'
-end
+atlantis_installer 'default'
 ```

--- a/documentation/resource_terraform_installer.md
+++ b/documentation/resource_terraform_installer.md
@@ -24,8 +24,5 @@
 ## Examples
 
 ```ruby
-terraform_installer 'terraform' do
-  version '0.13.3'
-  checksum '35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b'
-end
+terraform_installer 'default'
 ```

--- a/documentation/resource_terraform_installer.md
+++ b/documentation/resource_terraform_installer.md
@@ -17,7 +17,7 @@
 | checksum                    | String          |                                                             | Required      |
 | download_base_url           | String          | `https://releases.hashicorp.com`                            |               |
 | group                       | String, Integer | `atlantis`                                                  |               |
-| owner                       | String, Integer | `atlantis`                                                  |               |
+| owner                       | String          | `atlantis`                                                  |               |
 | mode                        | String, Integer | `0755`                                                      |               |
 | version                     | String          |                                                             | Required      |
 

--- a/documentation/resource_terraform_installer.md
+++ b/documentation/resource_terraform_installer.md
@@ -11,21 +11,21 @@
 
 ## Properties
 
-| name                        | Type            | Default                                                     | Description   |
-| --------------------------- | --------------- | ----------------------------------------------------------- | ------------- |
-| append_version_to_file      | true, false     | false                                                       |               |
-| checksum                    | String          |                                                             | Required      |
-| download_base_url           | String          | `https://releases.hashicorp.com`                            |               |
-| group                       | String, Integer | `atlantis`                                                  |               |
-| owner                       | String          | `atlantis`                                                  |               |
-| mode                        | String, Integer | `0755`                                                      |               |
-| version                     | String          |                                                             | Required      |
+| name                        | Type            | Default                                                            | Description   |
+| --------------------------- | --------------- | ------------------------------------------------------------------ | ------------- |
+| append_version_to_file      | true, false     | false                                                              |               |
+| checksum                    | String          | `35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b` | Required      |
+| download_base_url           | String          | `https://releases.hashicorp.com`                                   |               |
+| group                       | String, Integer | `atlantis`                                                         |               |
+| owner                       | String          | `atlantis`                                                         |               |
+| mode                        | String, Integer | `0755`                                                             |               |
+| version                     | String          | `0.13.3`                                                           | Required      |
 
 ## Examples
 
 ```ruby
 terraform_installer 'terraform' do
-  version '0.11.7'
-  checksum '6b8ce67647a59b2a3f70199c304abca0ddec0e49fd060944c26f666298e23418'
+  version '0.13.3'
+  checksum '35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b'
 end
 ```

--- a/documentation/resource_terragrunt_installer.md
+++ b/documentation/resource_terragrunt_installer.md
@@ -11,14 +11,14 @@
 
 ## Properties
 
-| name                        | Type            | Default                                                        | Description   |
-| --------------------------- | --------------- | -------------------------------------------------------------- | ------------- |
-| checksum                    | String          |                                                                | Required      |
-| download_base_url           | String          | `https://github.com/gruntwork-io/terragrunt/releases/download` |               |
-| group                       | String, Integer | `atlantis`                                                     |               |
-| owner                       | String          | `atlantis`                                                     |               |
-| mode                        | String, Integer | `0755`                                                         |               |
-| version                     | String          |                                                                | Required      |
+| name                        | Type            | Default                                                            | Description   |
+| --------------------------- | --------------- | ------------------------------------------------------------------ | ------------- |
+| checksum                    | String          | `3b033389977ca6e7d10bad10514f22fa767c85b76db92befe83e67bafa2c8413` | Required      |
+| download_base_url           | String          | `https://github.com/gruntwork-io/terragrunt/releases/download`     |               |
+| group                       | String, Integer | `atlantis`                                                         |               |
+| owner                       | String          | `atlantis`                                                         |               |
+| mode                        | String, Integer | `0755`                                                             |               |
+| version                     | String          | `0.25.4`                                                           | Required      |
 
 ## Examples
 

--- a/documentation/resource_terragrunt_installer.md
+++ b/documentation/resource_terragrunt_installer.md
@@ -71,8 +71,5 @@ atlantis_config 'repo-config' do
   template_variables terragrunt_repo_config
 end
 
-terragrunt_installer 'terragrunt' do
-  version '0.25.4'
-  checksum '3b033389977ca6e7d10bad10514f22fa767c85b76db92befe83e67bafa2c8413'
-end
+terragrunt_installer 'default'
 ```

--- a/documentation/resource_terragrunt_installer.md
+++ b/documentation/resource_terragrunt_installer.md
@@ -1,41 +1,28 @@
-# frozen_string_literal: true
+[back to resource list](https://github.com/sous-chefs/atlantis#resources)
 
-# setup atlantis user/group
-atlantis_user_group_setup 'atlantis' do
-  username 'atlantis'
-  groupname 'atlantis'
-end
+---
 
-# drop down atlantis config
-# create a local hash for testing
-config_vars = {
-  'atlantis-url'          => 'https://localhost:4141',
-  'allow-repo-config'     => false,
-  'gh-user'               => 'my-atlantis-bot',
-  'gh-token'              => 'A_GITHUB_TOKEN',
-  'gh-webhook-secret'     => 'A_GITHUB_WEBHOOK_SECRET',
-  'log-level'             => 'info',
-  'port'                  => 4141,
-  'repo-allowlist'        => %w(org/repo1 org/repo2).join(','),
-}
+# terragrunt_installer
 
-atlantis_config 'atlantis' do
-  template_variables config_vars
-end
+## Actions
 
-# install required dependencies
-package %w(unzip git)
+- `:install` [default]
+- `:remove`
 
-atlantis_installer 'atlantis' do
-  version '0.15.0'
-  checksum 'a236e7c9df159f8787b143c670f1899dd4bc4349f23ed696468600280fa1266e'
-end
+## Properties
 
-terraform_installer 'terraform' do
-  version '0.13.3'
-  checksum '35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b'
-end
+| name                        | Type            | Default                                                        | Description   |
+| --------------------------- | --------------- | -------------------------------------------------------------- | ------------- |
+| checksum                    | String          |                                                                | Required      |
+| download_base_url           | String          | `https://github.com/gruntwork-io/terragrunt/releases/download` |               |
+| group                       | String, Integer | `atlantis`                                                     |               |
+| owner                       | String          | `atlantis`                                                     |               |
+| mode                        | String, Integer | `0755`                                                         |               |
+| version                     | String          |                                                                | Required      |
 
+## Examples
+
+```ruby
 terragrunt_repo_config = {
   'repos' => [
     {
@@ -88,12 +75,4 @@ terragrunt_installer 'terragrunt' do
   version '0.25.4'
   checksum '3b033389977ca6e7d10bad10514f22fa767c85b76db92befe83e67bafa2c8413'
 end
-
-if node['platform_version'] == '14.04'
-  atlantis_service_upstart 'atlantis'
-else
-  atlantis_service_systemd 'atlantis' do
-    use_exec_stop false
-    environment ['John=Basement', 'Tom=Roof']
-  end
-end
+```

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,6 +19,10 @@ module AtlantisCookbook
       # https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
       "#{base_url}/#{product}/#{version}/#{product}_#{version}_linux_#{cpu_arch}.zip"
     end
+
+    def terragrunt_github_download_url(base_url, version)
+      # https://github.com/gruntwork-io/terragrunt/releases/download/v0.25.4/terragrunt_linux_amd64
+      "#{base_url}/v#{version}/terragrunt_linux_#{cpu_arch}"
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -2,12 +2,6 @@
 
 module AtlantisCookbook
   module Helpers
-    # require 'mixlib/shellout'
-
-    def linux?
-      node['kernel']['name'] == 'Linux'
-    end
-
     def cpu_arch
       if node['kernel']['processor'].match?(/x86_64/)
         'amd64'
@@ -16,22 +10,15 @@ module AtlantisCookbook
       end
     end
 
-    def os
-      if linux?
-        'linux'
-      else
-        node['platform']
-      end
-    end
-
     def github_download_url(base_url, version)
       # https://github.com/runatlantis/atlantis/releases/download/v0.4.4/atlantis_linux_amd64.zip
-      "#{base_url}/v#{version}/atlantis_#{os}_#{cpu_arch}.zip"
+      "#{base_url}/v#{version}/atlantis_linux_#{cpu_arch}.zip"
     end
 
     def hashicorp_download_url(base_url, product, version)
       # https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
-      "#{base_url}/#{product}/#{version}/#{product}_#{version}_#{os}_#{cpu_arch}.zip"
+      "#{base_url}/#{product}/#{version}/#{product}_#{version}_linux_#{cpu_arch}.zip"
+    end
     end
   end
 end

--- a/resources/installer.rb
+++ b/resources/installer.rb
@@ -4,13 +4,13 @@ include AtlantisCookbook::Helpers
 resource_name :atlantis_installer
 provides :atlantis_installer
 
-property :checksum, String, regex: /^[a-zA-Z0-9]{64}$/
+property :checksum, String, regex: /^[a-zA-Z0-9]{64}$/, default: 'a236e7c9df159f8787b143c670f1899dd4bc4349f23ed696468600280fa1266e'
 property :download_base_url, String, default: 'https://github.com/runatlantis/atlantis/releases/download'
 property :group, [String, Integer], default: 'atlantis'
 property :owner, String, default: 'atlantis'
 
 property :mode, [String, Integer], default: '0755'
-property :version, String, required: true
+property :version, String, default: '0.15.0'
 
 default_action :install
 

--- a/resources/installer.rb
+++ b/resources/installer.rb
@@ -7,7 +7,7 @@ provides :atlantis_installer
 property :checksum, String, regex: /^[a-zA-Z0-9]{64}$/
 property :download_base_url, String, default: 'https://github.com/runatlantis/atlantis/releases/download'
 property :group, [String, Integer], default: 'atlantis'
-property :owner, [String, Integer], default: 'atlantis'
+property :owner, String, default: 'atlantis'
 
 property :mode, [String, Integer], default: '0755'
 property :version, String, required: true

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -6,13 +6,12 @@ provides :atlantis_service_systemd
 
 property :atlantis_bin_location, String, default: '/usr/local/bin/atlantis'
 property :atlantis_config_name, String, default: 'atlantis.yaml'
-property :atlantis_group, String, default: 'atlantis'
 property :atlantis_home, String, default: '/opt/atlantis'
 property :timeout_stop_sec, [Integer, String], default: 5
 # The exit status code 143 = 128 + 15 = default terminate by system when the application doesn't have one
 property :atlantis_success_exit_status, [Integer, String], default: 143
 property :atlantis_user, String, default: 'atlantis'
-property :atlantis_user, String, default: 'atlantis'
+property :atlantis_group, String, default: 'atlantis'
 property :use_exec_stop, [true, false], default: true
 property :environment, [String, Array]
 property :environment_file, [String, Array]

--- a/resources/terraform_installer.rb
+++ b/resources/terraform_installer.rb
@@ -5,14 +5,14 @@ resource_name :terraform_installer
 provides :terraform_installer
 
 property :append_version_to_file, [true, false], default: false
-property :checksum, String, regex: /^[a-zA-Z0-9]{64}$/
+property :checksum, String, regex: /^[a-zA-Z0-9]{64}$/, default: '35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b'
 property :download_base_url, String, default: 'https://releases.hashicorp.com'
 
 property :group, [String, Integer], default: 'atlantis'
 property :owner, String, default: 'atlantis'
 property :mode, [String, Integer], default: '0755'
 
-property :version, String, required: true
+property :version, String, default: '0.13.3'
 
 default_action :install
 

--- a/resources/terraform_installer.rb
+++ b/resources/terraform_installer.rb
@@ -1,9 +1,4 @@
 # frozen_string_literal: true
-
-# include our helpers
-
-# install terraform
-# TODO: install terraform via https://github.com/haidangwa/chef-terraform or other
 include AtlantisCookbook::Helpers
 
 resource_name :terraform_installer

--- a/resources/terragrunt_installer.rb
+++ b/resources/terragrunt_installer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+include AtlantisCookbook::Helpers
+
+resource_name :terragrunt_installer
+provides :terragrunt_installer
+
+property :checksum, String, regex: /^[a-zA-Z0-9]{64}$/
+property :download_base_url, String, default: 'https://github.com/gruntwork-io/terragrunt/releases/download'
+
+property :group, [String, Integer], default: 'atlantis'
+property :owner, [String, Integer], default: 'atlantis'
+property :mode, [String, Integer], default: '0755'
+
+property :version, String, required: true
+
+default_action :install
+
+action :install do
+  remote_file '/usr/local/bin/terragrunt' do
+    source terragrunt_github_download_url(new_resource.download_base_url, new_resource.version)
+    checksum new_resource.checksum unless new_resource.checksum.nil?
+
+    owner new_resource.owner
+    group new_resource.group
+    mode new_resource.mode
+  end
+end
+
+action :remove do
+  file '/usr/local/bin/terragrunt' do
+    action :delete
+  end
+end

--- a/resources/terragrunt_installer.rb
+++ b/resources/terragrunt_installer.rb
@@ -4,14 +4,14 @@ include AtlantisCookbook::Helpers
 resource_name :terragrunt_installer
 provides :terragrunt_installer
 
-property :checksum, String, regex: /^[a-zA-Z0-9]{64}$/
+property :checksum, String, regex: /^[a-zA-Z0-9]{64}$/, default: '3b033389977ca6e7d10bad10514f22fa767c85b76db92befe83e67bafa2c8413'
 property :download_base_url, String, default: 'https://github.com/gruntwork-io/terragrunt/releases/download'
 
-property :group, [String, Integer], default: 'atlantis'
-property :owner, [String, Integer], default: 'atlantis'
+property :group, [String, Integer], default: 'root'
+property :owner, [String, Integer], default: 'root'
 property :mode, [String, Integer], default: '0755'
 
-property :version, String, required: true
+property :version, String, default: '0.25.4'
 
 default_action :install
 

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -26,15 +26,8 @@ end
 # install required dependencies
 package %w(unzip git)
 
-atlantis_installer 'atlantis' do
-  version '0.15.0'
-  checksum 'a236e7c9df159f8787b143c670f1899dd4bc4349f23ed696468600280fa1266e'
-end
-
-terraform_installer 'terraform' do
-  version '0.13.3'
-  checksum '35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b'
-end
+atlantis_installer 'atlantis'
+terraform_installer 'terraform'
 
 terragrunt_repo_config = {
   'repos' => [
@@ -84,10 +77,7 @@ atlantis_config 'repo-config' do
   template_variables terragrunt_repo_config
 end
 
-terragrunt_installer 'terragrunt' do
-  version '0.25.4'
-  checksum '3b033389977ca6e7d10bad10514f22fa767c85b76db92befe83e67bafa2c8413'
-end
+terragrunt_installer 'terragrunt'
 
 if node['platform_version'] == '14.04'
   atlantis_service_upstart 'atlantis'

--- a/test/integration/default/atlantis.rb
+++ b/test/integration/default/atlantis.rb
@@ -15,7 +15,7 @@ describe file(atlantis_bin) do
 end
 
 describe command("#{atlantis_bin} version") do
-  its('stdout') { should match(/(atlantis)\s([0-9]+\.){2}[0-9+]/) }
+  its('stdout') { should match(/(atlantis)\s0.15.0/) }
   its('exit_status') { should eq 0 }
 end
 

--- a/test/integration/default/terraform.rb
+++ b/test/integration/default/terraform.rb
@@ -15,6 +15,6 @@ describe file(terraform_bin) do
 end
 
 describe command("#{terraform_bin} --version") do
-  its('stdout') { should match(/(Terraform)\sv([0-9]+\.){2}[0-9+]/) }
+  its('stdout') { should match(/(Terraform)\sv0.13.3/) }
   its('exit_status') { should eq 0 }
 end

--- a/test/integration/default/terragrunt.rb
+++ b/test/integration/default/terragrunt.rb
@@ -15,6 +15,6 @@ describe file(terragrunt_bin) do
 end
 
 describe command("#{terragrunt_bin} --version") do
-  its('stdout') { should match(/terragrunt\sversion\sv([0-9]+\.){2}[0-9+]/) }
+  its('stdout') { should match(/terragrunt\sversion\sv0.25.4/) }
   its('exit_status') { should eq 0 }
 end

--- a/test/integration/default/terragrunt.rb
+++ b/test/integration/default/terragrunt.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+terragrunt_bin = '/usr/local/bin/terragrunt'
+
+describe file(terragrunt_bin) do
+  it { should exist }
+  its('type') { should eq :file }
+  it { should_not be_directory }
+  it { should be_executable }
+  # to get the latest sha you should download the zip archive and extract it
+  # if needed you may have to install `coreutils` (package name for deb derivitives)
+  # root@dokken:/# sha256sum /usr/local/bin/terragrunt/terragrunt
+  # 00cc2e727e662fb81c789b2b8371d82d6be203ddc76c49232ed9c17b4980949a  /usr/local/bin/terragrunt/terragrunt
+  its('sha256sum') { should eq '3b033389977ca6e7d10bad10514f22fa767c85b76db92befe83e67bafa2c8413' }
+end
+
+describe command("#{terragrunt_bin} --version") do
+  its('stdout') { should match(/terragrunt\sversion\sv([0-9]+\.){2}[0-9+]/) }
+  its('exit_status') { should eq 0 }
+end


### PR DESCRIPTION
# Description
Its a bit daunting to add support to atlantis for terragrunt so i though it would be nice to have this built in to the cookbook so others can use it. the example config also includes some bash formatting magic to get nice clean output in PRs just like the built in atlantis formatter does for terraform output.

### Added

- Support for installing terragrunt and documentation of examples for configuration

### Fixed

- Ark only support intergers on groups not owners
- Systemd resource user property was listed twice

## Issues Resolved

[List any existing issues this PR resolves]

## Check List

- [x] All tests pass. See https://github.com/sous-chefs/atlantis/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
